### PR TITLE
Add ClawBench to web and browser environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,7 @@ The process of defining objective feedback signals for GUI tasks.
 | [Webgpt: Browser-assisted question-answering with human feedback](https://arxiv.org/abs/2112.09332) | arXiv 2021 |
 | [Webvoyager: Building an end-to-end web agent with large multimodal models](https://arxiv.org/abs/2401.13919) | ACL |
 | [World of bits: An open-domain platform for web-based agents](https://proceedings.mlr.press/v70/shi17a.html) | ICML |
+| [ClawBench: Can AI Agents Complete Everyday Online Tasks?](https://arxiv.org/abs/2604.08523) | arXiv 2026 |
 
 
 


### PR DESCRIPTION
## Summary

- Add ClawBench to **Training Resources → Interactive Environments → Web and Browser Environments**.
- Use the existing two-column Paper Title / Year table format and the canonical [arXiv paper](https://arxiv.org/abs/2604.08523).

ClawBench provides live-site browser tasks and a containerized evaluation environment with action, screenshot, network, replay, and agent-message traces, making it a relevant public environment for GUI-agent research. The [project site](https://claw-bench.com/) and [repository](https://github.com/reacher-z/ClawBench) provide the implementation details.

## Validation

- Searched the full upstream branch for `ClawBench`, `2604.08523`, and `claw-bench.com`; no existing entry was found.
- Confirmed the new row has the same two-column shape as the surrounding table.
- Ran `git diff --check` and verified the linked resources return HTTP 200.

Disclosure: I am a ClawBench maintainer.